### PR TITLE
[builder] Fix directory creation issue

### DIFF
--- a/ccbuilder/builder/builder.py
+++ b/ccbuilder/builder/builder.py
@@ -270,7 +270,7 @@ def build_and_install_compiler(
 
     if not logdir:
         logdir = cache_prefix / "logs"
-    logdir.mkdir(exist_ok=True)
+    logdir.mkdir(exist_ok=True, parents=True)
     with BuildContext(install_prefix, success_indicator, project, commit, logdir) as (
         tmpdir,
         build_log,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ccbuilder
-version = 0.0.8
+version = 0.0.9
 author = Theodoros Theodoridis
 author_email = theodort@inf.ethz.ch
 description = A clang/gcc compiler builder and patcher


### PR DESCRIPTION
The logs directory is created before its parent directory and
mkdir would fail without parents=True.

Closes #23 