### PR TITLE
[builder] fix success indicator out of BuildContext

### DIFF
--- a/ccbuilder/builder/builder.py
+++ b/ccbuilder/builder/builder.py
@@ -294,7 +294,7 @@ def build_and_install_compiler(
             jobs if jobs else multiprocessing.cpu_count(),
             build_log,
         )
-    success_indicator.touch()
+        success_indicator.touch()
     repo.prune_worktree()
     if get_executable:
         return res / get_executable_postfix(project)


### PR DESCRIPTION
Should fix #34 