### PR TITLE
[packaging] fix including patches in package build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include ccbuilder/data/*/*
+include ccbuilder/data/*/*/*
 include ccbuilder/py.typed


### PR DESCRIPTION
(At least) the newest install of ccbuilder does not include the patches and hence is broken. 